### PR TITLE
Add Force Density initialization option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,25 @@ After installing the package, launch the Streamlit application with:
 ```bash
 streamlit run examples/app.py
 ```
+
+## FDM 初期化
+
+The Force Density Method (FDM) provides an analytical starting shape by
+solving a linear system for the free node coordinates.
+For a cable network with force densities $q$, the equilibrium is
+
+\begin{equation}
+L_{ff} \mathbf{X}_f = -L_{fb} \mathbf{X}_b,
+\end{equation}
+
+where $L$ is assembled from the cable force densities and $\mathbf{X}_b$
+are the coordinates of fixed nodes. The solution $\mathbf{X}_f$ is used as
+the initial configuration for dynamic relaxation.
+
+Enable this initialization with:
+
+```python
+dynamic_relaxation(model, use_fdm=True)
+```
+
+This typically reduces the number of iterations required for convergence.

--- a/src/tensegritylab/__init__.py
+++ b/src/tensegritylab/__init__.py
@@ -1,3 +1,4 @@
 from .dr import build_snelson_prism, dynamic_relaxation
+from .fdm import fdm_initialize
 
-__all__ = ["build_snelson_prism", "dynamic_relaxation"]
+__all__ = ["build_snelson_prism", "dynamic_relaxation", "fdm_initialize"]

--- a/src/tensegritylab/dr.py
+++ b/src/tensegritylab/dr.py
@@ -25,6 +25,7 @@ def dynamic_relaxation(
     g: float | None = None,
     verbose: bool = True,
     callback=None,
+    use_fdm: bool = False,
 ):
     """Dynamic relaxation solver.
 
@@ -46,7 +47,13 @@ def dynamic_relaxation(
         Called every iteration with current step and RMS.
     """
 
-    X = model.X.copy()
+    if use_fdm:
+        from .fdm import fdm_initialize
+
+        q_cable = [m["EA"] / m["L0"] for m in model.members if m["kind"] == "cable"]
+        X = fdm_initialize(model, q_cable, fixed=model.fixed)
+    else:
+        X = model.X.copy()
     V = np.zeros_like(X)
     M = np.full((model.N, 1), mass, dtype=float)
     Pext = np.zeros_like(X)

--- a/src/tensegritylab/fdm.py
+++ b/src/tensegritylab/fdm.py
@@ -1,0 +1,88 @@
+import numpy as np
+
+
+def fdm_initialize(model, q_cable, fixed=None):
+    """Initialize node positions using the Force Density Method.
+
+    Parameters
+    ----------
+    model : TensegrityModel
+        Structure definition. Only cable members are considered.
+    q_cable : float or array-like
+        Force densities for cable members. If scalar, the same density is
+        applied to all cables. If array-like, it must match the number of
+        cable members.
+    fixed : array-like of bool, optional
+        Boolean mask of fixed nodes. If ``None`` uses ``model.fixed``.
+
+    Returns
+    -------
+    ndarray
+        Node coordinates computed by the FDM. Nodes not connected to any
+        fixed node are left unchanged.
+    """
+
+    X = np.asarray(model.X, dtype=float)
+    N = X.shape[0]
+
+    if fixed is None:
+        fixed = model.fixed
+    fixed = np.asarray(fixed, dtype=bool)
+
+    # Collect cable members and adjacency for graph traversal
+    cables = []
+    adj = {i: set() for i in range(N)}
+    for m in model.members:
+        if m["kind"] != "cable":
+            continue
+        i, j = m["i"], m["j"]
+        cables.append((i, j))
+        adj[i].add(j)
+        adj[j].add(i)
+
+    # Determine subnet connected to fixed nodes to avoid degeneracy
+    if fixed.any():
+        visited = set(np.where(fixed)[0])
+        queue = list(visited)
+        while queue:
+            i = queue.pop(0)
+            for j in adj[i]:
+                if j not in visited:
+                    visited.add(j)
+                    queue.append(j)
+        mask = np.zeros(N, dtype=bool)
+        mask[list(visited)] = True
+    else:
+        mask = np.ones(N, dtype=bool)
+
+    free = ~fixed & mask
+    if not np.any(free):
+        return X.copy()
+
+    # Force density matrix (Laplacian-like)
+    L = np.zeros((N, N))
+    if np.isscalar(q_cable):
+        q_vals = [float(q_cable)] * len(cables)
+    else:
+        q_vals = np.asarray(q_cable, dtype=float)
+        if q_vals.size != len(cables):
+            raise ValueError("q_cable must match number of cable members")
+    for (i, j), q in zip(cables, q_vals):
+        L[i, i] += q
+        L[j, j] += q
+        L[i, j] -= q
+        L[j, i] -= q
+
+    idx_free = np.where(free)[0]
+    idx_fixed = np.where(fixed & mask)[0]
+    L_ff = L[np.ix_(idx_free, idx_free)]
+    L_fb = L[np.ix_(idx_free, idx_fixed)]
+    B = -L_fb @ X[idx_fixed]
+    X_sol = np.linalg.solve(L_ff, B)
+
+    X0 = X.copy()
+    X0[idx_free] = X_sol
+    return X0
+
+
+__all__ = ["fdm_initialize"]

--- a/tests/test_fdm_init.py
+++ b/tests/test_fdm_init.py
@@ -1,0 +1,12 @@
+from tensegritylab.dr import build_snelson_prism, dynamic_relaxation
+
+
+def test_fdm_initialization_reduces_steps():
+    model = build_snelson_prism()
+    _, _, info_plain = dynamic_relaxation(
+        model, tol=1e-6, max_steps=20000, verbose=False, use_fdm=False
+    )
+    _, _, info_fdm = dynamic_relaxation(
+        model, tol=1e-6, max_steps=20000, verbose=False, use_fdm=True
+    )
+    assert info_fdm["steps"] < info_plain["steps"]


### PR DESCRIPTION
## Summary
- add `fdm_initialize` implementing the Force Density Method for initial coordinates
- allow `dynamic_relaxation` to optionally use FDM with `use_fdm`
- document FDM initialization and add regression test

## Testing
- `pytest tests/test_fdm_init.py::test_fdm_initialization_reduces_steps -q` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b59c522398832ca08c80f0e571dd39