### PR TITLE
Add CSV/JSON export utilities and Streamlit downloads

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -1,9 +1,15 @@
+import json
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
 
-from tensegritylab.dr import build_snelson_prism, dynamic_relaxation
+from tensegritylab.dr import (
+    build_snelson_prism,
+    dynamic_relaxation,
+    to_member_dataframe,
+    to_structure_json,
+)
 
 st.title("Tensegrity Dynamic Relaxation")
 
@@ -58,7 +64,13 @@ if st.button("Solve"):
     fig.update_layout(scene=dict(aspectmode="data"), showlegend=False)
     st.plotly_chart(fig, use_container_width=True)
 
-    df = pd.DataFrame(forces)[["kind", "L", "force"]]
+    df = to_member_dataframe(model, X, forces)
     st.dataframe(df)
     csv = df.to_csv(index=False).encode("utf-8")
     st.download_button("Download CSV", csv, "forces.csv", "text/csv")
+
+    js = to_structure_json(model, X)
+    js_str = json.dumps(js)
+    st.download_button(
+        "Download JSON", js_str, "structure.json", "application/json"
+    )

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from tensegritylab.dr import (
+    build_snelson_prism,
+    dynamic_relaxation,
+    to_member_dataframe,
+    to_structure_json,
+)
+
+
+def test_export_dataframe_and_json_consistency():
+    model = build_snelson_prism()
+    X, forces, _ = dynamic_relaxation(model, tol=1e-6, max_steps=20000, verbose=False)
+
+    df = to_member_dataframe(model, X, forces)
+    assert list(df.columns) == ["kind", "i", "j", "L", "force"]
+    assert len(df) == len(model.members)
+    lengths = [np.linalg.norm(X[m["j"]] - X[m["i"]]) for m in model.members]
+    assert np.allclose(df["L"], lengths)
+
+    js = to_structure_json(model, X)
+    assert np.allclose(js["nodes"], X)
+    assert js["fixed"] == model.fixed.tolist()
+    assert df["i"].tolist() == [m["i"] for m in js["members"]]
+    assert df["j"].tolist() == [m["j"] for m in js["members"]]
+    assert df["kind"].tolist() == [m["kind"] for m in js["members"]]


### PR DESCRIPTION
## Summary
- add `to_member_dataframe` and `to_structure_json` helpers for exporting models
- enhance Streamlit example with CSV and JSON download buttons
- test export helpers for consistency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b791851e24832caa2ecaa4ab30ddab