### PR TITLE
Add Euler buckling safety check for struts

### DIFF
--- a/tests/test_buckling.py
+++ b/tests/test_buckling.py
@@ -1,0 +1,30 @@
+import numpy as np
+from tensegritylab.dr import (
+    build_snelson_prism,
+    dynamic_relaxation,
+    buckling_safety_for_struts,
+)
+
+
+def test_buckling_safety_positive_and_skip_zero():
+    model = build_snelson_prism()
+    X, forces, _ = dynamic_relaxation(model, verbose=False)
+
+    # Append a zero-force strut to ensure it's skipped
+    forces.append({
+        "i": 0,
+        "j": 1,
+        "kind": "strut",
+        "EA": 0.0,
+        "L0": 1.0,
+        "L": 1.0,
+        "force": 0.0,
+    })
+
+    data = buckling_safety_for_struts(model, X, forces, EI=1.0, K=1.0)
+
+    # Original model has 3 struts; the zero-force strut should be skipped
+    assert len(data) == 3
+    for d in data:
+        assert d["safety"] > 0
+        assert np.isfinite(d["safety"])


### PR DESCRIPTION
## Summary
- add `buckling_safety_for_struts` to compute Euler critical loads and safety factors
- expose buckling safety table and CSV download in Streamlit example
- test buckling safety computation and zero-force filtering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7d41a08c4832c86a9e7f93ee1fb1c