### PR TITLE
Improve demo UX and document exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,15 @@ dynamic_relaxation(model, use_fdm=True)
 This typically reduces the number of iterations required for convergence.
 The Streamlit demo provides a *Use FDM initialization* checkbox to toggle
 this behaviour interactively.
+
+## 出力
+
+Member forces can be exported to CSV via `to_member_dataframe`, while
+`to_structure_json` serializes the geometry and member data to JSON.
+The Streamlit demo offers download buttons for both formats.
+
+## 座屈チェック
+
+`buckling_safety_for_struts` evaluates Euler buckling safety factors for
+compressive members. Values below a chosen threshold (e.g. 1.5) highlight
+struts that may require redesign.


### PR DESCRIPTION
## Summary
- Show spinner with progress and metrics when solving
- Highlight FDM initialization and refine numeric input ranges
- Document CSV/JSON exports and buckling safety checks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7d704c70c832cb4df19fc34c4042e