### PR TITLE
Add presets and JSON save/load features

### DIFF
--- a/src/tensegritylab/__init__.py
+++ b/src/tensegritylab/__init__.py
@@ -1,4 +1,11 @@
-from .dr import build_snelson_prism, dynamic_relaxation
+from .presets import build_snelson_prism, build_quadruple_prism, build_quintuple_prism
+from .dr import dynamic_relaxation
 from .fdm import fdm_initialize
 
-__all__ = ["build_snelson_prism", "dynamic_relaxation", "fdm_initialize"]
+__all__ = [
+    "build_snelson_prism",
+    "build_quadruple_prism",
+    "build_quintuple_prism",
+    "dynamic_relaxation",
+    "fdm_initialize",
+]

--- a/src/tensegritylab/presets.py
+++ b/src/tensegritylab/presets.py
@@ -1,0 +1,126 @@
+import numpy as np
+
+
+def _build_prism(
+    n: int,
+    r: float = 1.0,
+    h: float = 1.2,
+    theta: float = np.deg2rad(150),
+    EA_cable: float = 1.0,
+    EA_strut: float = 10.0,
+    cable_L0_scale: float = 0.95,
+    strut_L0_scale: float = 1.20,
+) -> "TensegrityModel":
+    """Internal helper to create an n-sided prism."""
+
+    from .dr import TensegrityModel
+
+    B = np.array(
+        [[r * np.cos(2 * np.pi * k / n), r * np.sin(2 * np.pi * k / n), 0.0] for k in range(n)]
+    )
+    T = np.array(
+        [
+            [
+                r * np.cos(2 * np.pi * k / n + theta),
+                r * np.sin(2 * np.pi * k / n + theta),
+                h,
+            ]
+            for k in range(n)
+        ]
+    )
+    X0 = np.vstack([B, T])
+
+    members: list[dict] = []
+
+    def add(i: int, j: int, kind: str, EA: float, L0_scale: float) -> None:
+        L = np.linalg.norm(X0[j] - X0[i])
+        members.append({"i": i, "j": j, "kind": kind, "EA": EA, "L0": L0_scale * L})
+
+    for k in range(n):
+        add(k, n + ((k + 1) % n), "strut", EA_strut, strut_L0_scale)
+
+    for k in range(n):
+        add(k, (k + 1) % n, "cable", EA_cable, cable_L0_scale)
+        add(n + k, n + ((k + 1) % n), "cable", EA_cable, cable_L0_scale)
+        add(k, n + k, "cable", EA_cable, cable_L0_scale)
+        add(k, n + ((k - 1) % n), "cable", EA_cable, cable_L0_scale)
+
+    fixed = np.zeros(2 * n, dtype=bool)
+    fixed[:n] = True
+    return TensegrityModel(X0, members, fixed)
+
+
+def build_snelson_prism(
+    r: float = 1.0,
+    h: float = 1.2,
+    theta: float = np.deg2rad(150),
+    EA_cable: float = 1.0,
+    EA_strut: float = 10.0,
+    cable_L0_scale: float = 0.95,
+    strut_L0_scale: float = 1.20,
+) -> "TensegrityModel":
+    """Create a 3-strut Snelson prism model."""
+
+    return _build_prism(
+        3,
+        r=r,
+        h=h,
+        theta=theta,
+        EA_cable=EA_cable,
+        EA_strut=EA_strut,
+        cable_L0_scale=cable_L0_scale,
+        strut_L0_scale=strut_L0_scale,
+    )
+
+
+def build_quadruple_prism(
+    r: float = 1.0,
+    h: float = 1.2,
+    theta: float = np.deg2rad(135),
+    EA_cable: float = 1.0,
+    EA_strut: float = 10.0,
+    cable_L0_scale: float = 0.95,
+    strut_L0_scale: float = 1.20,
+) -> "TensegrityModel":
+    """Create a 4-strut prism model."""
+
+    return _build_prism(
+        4,
+        r=r,
+        h=h,
+        theta=theta,
+        EA_cable=EA_cable,
+        EA_strut=EA_strut,
+        cable_L0_scale=cable_L0_scale,
+        strut_L0_scale=strut_L0_scale,
+    )
+
+
+def build_quintuple_prism(
+    r: float = 1.0,
+    h: float = 1.2,
+    theta: float = np.deg2rad(140),
+    EA_cable: float = 1.0,
+    EA_strut: float = 10.0,
+    cable_L0_scale: float = 0.95,
+    strut_L0_scale: float = 1.20,
+) -> "TensegrityModel":
+    """Create a 5-strut prism model."""
+
+    return _build_prism(
+        5,
+        r=r,
+        h=h,
+        theta=theta,
+        EA_cable=EA_cable,
+        EA_strut=EA_strut,
+        cable_L0_scale=cable_L0_scale,
+        strut_L0_scale=strut_L0_scale,
+    )
+
+
+__all__ = [
+    "build_snelson_prism",
+    "build_quadruple_prism",
+    "build_quintuple_prism",
+]

--- a/tests/test_io_presets.py
+++ b/tests/test_io_presets.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from tensegritylab.presets import build_snelson_prism, build_quadruple_prism
+from tensegritylab.dr import TensegrityModel, dynamic_relaxation, to_structure_json
+
+
+def test_json_round_trip():
+    model = build_snelson_prism()
+    X, forces, _ = dynamic_relaxation(model, tol=1e-6, max_steps=20000, verbose=False)
+    js = to_structure_json(model, X)
+    model2 = TensegrityModel(js["nodes"], js["members"], js["fixed"])
+    js2 = to_structure_json(model2, np.array(js["nodes"]))
+    assert js == js2
+
+
+def test_quadruple_prism_basic():
+    model = build_quadruple_prism()
+    assert model.X.shape == (8, 3)
+    struts = [m for m in model.members if m["kind"] == "strut"]
+    assert len(struts) == 4
+    assert model.fixed.sum() == 4


### PR DESCRIPTION
## Summary
- add general prism presets including 4- and 5-strut versions
- expose preset builders and add JSON save/load to Streamlit example
- verify preset generation and JSON round-trip in new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7d9210164832c84e768fff5f258f8