### PR TITLE
Add prestress sweep optimization and UI

### DIFF
--- a/src/tensegritylab/__init__.py
+++ b/src/tensegritylab/__init__.py
@@ -1,6 +1,7 @@
 from .presets import build_snelson_prism, build_quadruple_prism, build_quintuple_prism
 from .dr import dynamic_relaxation
 from .fdm import fdm_initialize
+from .opt import sweep_prestress
 
 __all__ = [
     "build_snelson_prism",
@@ -8,4 +9,5 @@ __all__ = [
     "build_quintuple_prism",
     "dynamic_relaxation",
     "fdm_initialize",
+    "sweep_prestress",
 ]

--- a/src/tensegritylab/opt.py
+++ b/src/tensegritylab/opt.py
@@ -1,0 +1,108 @@
+"""Optimization utilities for prestress parameter sweeps."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import itertools
+from typing import Iterable, Tuple
+
+import numpy as np
+
+from .dr import dynamic_relaxation, buckling_safety_for_struts, TensegrityModel
+
+
+def _scale_model_L0(model: TensegrityModel, cable_scale: float, strut_scale: float) -> TensegrityModel:
+    """Return a copy of ``model`` with member rest lengths scaled.
+
+    Parameters
+    ----------
+    model : TensegrityModel
+        Base model whose ``L0`` values will be scaled.
+    cable_scale, strut_scale : float
+        Multipliers applied to cable and strut rest lengths respectively.
+    """
+
+    members = []
+    for m in model.members:
+        m2 = m.copy()
+        if m2["kind"] == "cable":
+            m2["L0"] *= cable_scale
+        else:
+            m2["L0"] *= strut_scale
+        members.append(m2)
+    return TensegrityModel(model.X, members, model.fixed)
+
+
+def sweep_prestress(
+    model: TensegrityModel,
+    cable_scales: Iterable[float],
+    strut_scales: Iterable[float],
+    metric: str = "min_tension_spread",
+):
+    """Sweep cable/strut rest-length scales and evaluate metrics.
+
+    Parameters
+    ----------
+    model : TensegrityModel
+        Base structure definition.
+    cable_scales, strut_scales : iterable of float
+        Multipliers applied to cable and strut rest lengths.
+    metric : {"min_tension_spread", "max_buckling_safety"}
+        Objective metric to evaluate. ``min_tension_spread`` seeks the
+        minimum spread between cable forces, while ``max_buckling_safety``
+        maximizes the minimum Euler buckling safety factor of struts.
+
+    Returns
+    -------
+    tuple
+        ``(best_params, history)`` where ``best_params`` is a ``dict`` with
+        ``cable_L0_scale``, ``strut_L0_scale`` and ``score`` keys, and
+        ``history`` is a :class:`pandas.DataFrame` of all evaluated cases.
+    """
+
+    import pandas as pd
+
+    results = []
+    for cs, ss in itertools.product(cable_scales, strut_scales):
+        test_model = _scale_model_L0(model, cs, ss)
+        X, forces, _ = dynamic_relaxation(test_model, verbose=False)
+        if metric == "min_tension_spread":
+            c_forces = [abs(f["force"]) for f in forces if f["kind"] == "cable"]
+            if c_forces:
+                score = max(c_forces) - min(c_forces)
+            else:
+                score = np.inf
+            better = "min"
+        elif metric == "max_buckling_safety":
+            buck = buckling_safety_for_struts(test_model, X, forces, EI=1.0, K=1.0)
+            if buck:
+                score = min(b["safety"] for b in buck)
+            else:
+                score = 0.0
+            better = "max"
+        else:
+            raise ValueError("unknown metric")
+        results.append({
+            "cable_L0_scale": cs,
+            "strut_L0_scale": ss,
+            "score": score,
+        })
+
+    history = pd.DataFrame(results)
+    if history.empty:
+        raise ValueError("empty sweep range")
+
+    if metric == "min_tension_spread":
+        idx = history["score"].idxmin()
+    else:
+        idx = history["score"].idxmax()
+    best_row = history.loc[idx]
+    best_params = {
+        "cable_L0_scale": float(best_row["cable_L0_scale"]),
+        "strut_L0_scale": float(best_row["strut_L0_scale"]),
+        "score": float(best_row["score"]),
+    }
+    return best_params, history
+
+
+__all__ = ["sweep_prestress"]

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -1,0 +1,15 @@
+import pandas as pd
+
+from tensegritylab.presets import build_snelson_prism
+from tensegritylab.opt import sweep_prestress
+
+
+def test_sweep_prestress_history_and_best():
+    model = build_snelson_prism()
+    cable_scales = [0.95, 1.0]
+    strut_scales = [1.0, 1.05]
+    best, history = sweep_prestress(model, cable_scales, strut_scales)
+    assert isinstance(best, dict)
+    assert isinstance(history, pd.DataFrame)
+    assert len(history) == len(cable_scales) * len(strut_scales)
+    assert {"cable_L0_scale", "strut_L0_scale", "score"}.issubset(best.keys())


### PR DESCRIPTION
## Summary
- add `sweep_prestress` utility to scan cable/strut rest-length scales and evaluate tension spread or buckling safety
- expose sweep function in package API and integrate optimization section into Streamlit example app
- cover sweep with unit test for result types and history length

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7e080f0d0832cbf250bb0cc985d9d