### PR TITLE
Add interactive strut editor

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -13,8 +13,212 @@ from tensegritylab.dr import (
     TensegrityModel,
 )
 from tensegritylab.opt import sweep_prestress
+from tensegritylab.planner import plan_cables_from_struts
+from tensegritylab.editor_state import add_strut, edit_strut, delete_strut
 
 st.title("Tensegrity Dynamic Relaxation")
+
+mode = st.radio("Mode", ["Preset", "Custom editor"], horizontal=True)
+
+if mode == "Custom editor":
+    st.header("Strut Editor")
+    struts = st.session_state.setdefault("struts", [])
+    selected = st.session_state.setdefault("selected_strut", 0)
+
+    col1, _, col3 = st.columns(3)
+    if col1.button("Add"):
+        struts = add_strut(struts, (0.0, 0.0, 0.0), (0.0, 0.0, 0.0))
+        st.session_state["struts"] = struts
+        st.session_state["selected_strut"] = len(struts) - 1
+
+    if struts:
+        idx = st.selectbox(
+            "Select strut", list(range(len(struts))), index=min(selected, len(struts) - 1)
+        )
+        st.session_state["selected_strut"] = idx
+        a, b = struts[idx]
+        ax = st.slider("Ax", -2.0, 2.0, float(a[0]), step=0.05)
+        ay = st.slider("Ay", -2.0, 2.0, float(a[1]), step=0.05)
+        az = st.slider("Az", -2.0, 2.0, float(a[2]), step=0.05)
+        bx = st.slider("Bx", -2.0, 2.0, float(b[0]), step=0.05)
+        by = st.slider("By", -2.0, 2.0, float(b[1]), step=0.05)
+        bz = st.slider("Bz", -2.0, 2.0, float(b[2]), step=0.05)
+        struts = edit_strut(struts, idx, (ax, ay, az), (bx, by, bz))
+        st.session_state["struts"] = struts
+
+        if col3.button("Delete"):
+            struts = delete_strut(struts, idx)
+            st.session_state["struts"] = struts
+            st.session_state["selected_strut"] = 0
+
+    df = pd.DataFrame(
+        [s[0] + s[1] for s in st.session_state["struts"]],
+        columns=["x0", "y0", "z0", "x1", "y1", "z1"],
+    )
+    edited_df = st.data_editor(df, num_rows="dynamic")
+    st.session_state["struts"] = [
+        ((row.x0, row.y0, row.z0), (row.x1, row.y1, row.z1))
+        for row in edited_df.itertuples(index=False)
+    ]
+
+    fig = go.Figure()
+    sx, sy, sz = [], [], []
+    nx, ny, nz = [], [], []
+    for a, b in st.session_state["struts"]:
+        sx.extend([a[0], b[0], None])
+        sy.extend([a[1], b[1], None])
+        sz.extend([a[2], b[2], None])
+        nx.extend([a[0], b[0]])
+        ny.extend([a[1], b[1]])
+        nz.extend([a[2], b[2]])
+    if st.session_state["struts"]:
+        fig.add_trace(
+            go.Scatter3d(
+                x=sx,
+                y=sy,
+                z=sz,
+                mode="lines",
+                line=dict(color="red", dash="dash"),
+                name="Strut",
+            )
+        )
+        fig.add_trace(
+            go.Scatter3d(
+                x=nx,
+                y=ny,
+                z=nz,
+                mode="markers",
+                marker=dict(color="black"),
+                name="Nodes",
+            )
+        )
+    fig.update_layout(scene=dict(aspectmode="data"))
+    st.plotly_chart(fig, use_container_width=True)
+
+    if st.button("Auto-plan Cables"):
+        model = plan_cables_from_struts(st.session_state["struts"])
+        st.session_state["planned_model"] = model
+
+    if "planned_model" in st.session_state:
+        model = st.session_state["planned_model"]
+        X = np.array([n.xyz for n in model.nodes])
+        cable_x, cable_y, cable_z = [], [], []
+        strut_x, strut_y, strut_z = [], [], []
+        for m in model.members:
+            i, j = m.i, m.j
+            xs = [X[i, 0], X[j, 0], None]
+            ys = [X[i, 1], X[j, 1], None]
+            zs = [X[i, 2], X[j, 2], None]
+            if m.kind == "cable":
+                cable_x.extend(xs)
+                cable_y.extend(ys)
+                cable_z.extend(zs)
+            else:
+                strut_x.extend(xs)
+                strut_y.extend(ys)
+                strut_z.extend(zs)
+        fig2 = go.Figure()
+        fig2.add_trace(
+            go.Scatter3d(
+                x=cable_x,
+                y=cable_y,
+                z=cable_z,
+                mode="lines",
+                line=dict(color="blue"),
+                name="Cable",
+            )
+        )
+        fig2.add_trace(
+            go.Scatter3d(
+                x=strut_x,
+                y=strut_y,
+                z=strut_z,
+                mode="lines",
+                line=dict(color="red", dash="dash"),
+                name="Strut",
+            )
+        )
+        fig2.add_trace(
+            go.Scatter3d(
+                x=X[:, 0],
+                y=X[:, 1],
+                z=X[:, 2],
+                mode="markers",
+                marker=dict(color="lightgray"),
+                name="Nodes",
+            )
+        )
+        fig2.update_layout(scene=dict(aspectmode="data"))
+        st.plotly_chart(fig2, use_container_width=True)
+
+        use_fdm = st.checkbox("Use FDM initialization", value=False, key="use_fdm_custom")
+        if st.button("Solve"):
+            progress = st.empty()
+
+            def cb(step, rms):
+                progress.text(f"step {step}: RMS={rms:.2e}")
+
+            with st.spinner("Solving..."):
+                X, forces, info = dynamic_relaxation(
+                    model, callback=cb, verbose=False, use_fdm=use_fdm
+                )
+
+            progress.text(
+                f"Converged in {info['steps']} steps, RMS={info['rms']:.2e}"
+            )
+            fig3 = go.Figure()
+            cable_x, cable_y, cable_z = [], [], []
+            strut_x, strut_y, strut_z = [], [], []
+            for m in model.members:
+                i, j = m.i, m.j
+                xs = [X[i, 0], X[j, 0], None]
+                ys = [X[i, 1], X[j, 1], None]
+                zs = [X[i, 2], X[j, 2], None]
+                if m.kind == "cable":
+                    cable_x.extend(xs)
+                    cable_y.extend(ys)
+                    cable_z.extend(zs)
+                else:
+                    strut_x.extend(xs)
+                    strut_y.extend(ys)
+                    strut_z.extend(zs)
+            fig3.add_trace(
+                go.Scatter3d(
+                    x=cable_x,
+                    y=cable_y,
+                    z=cable_z,
+                    mode="lines",
+                    line=dict(color="blue"),
+                    name="Cable",
+                )
+            )
+            fig3.add_trace(
+                go.Scatter3d(
+                    x=strut_x,
+                    y=strut_y,
+                    z=strut_z,
+                    mode="lines",
+                    line=dict(color="red"),
+                    name="Strut",
+                )
+            )
+            fig3.add_trace(
+                go.Scatter3d(
+                    x=X[:, 0],
+                    y=X[:, 1],
+                    z=X[:, 2],
+                    mode="markers",
+                    marker=dict(color="lightgray"),
+                    name="Nodes",
+                )
+            )
+            fig3.update_layout(scene=dict(aspectmode="data"), showlegend=True)
+            st.plotly_chart(fig3, use_container_width=True)
+
+            df = to_member_dataframe(model, X, forces)
+            st.dataframe(df)
+
+    st.stop()
 
 uploaded = st.file_uploader("Load JSON", type="json")
 default_idx = 2 if uploaded else 0

--- a/src/tensegritylab/editor_state.py
+++ b/src/tensegritylab/editor_state.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import List, Sequence, Tuple
+
+Strut = Tuple[Tuple[float, float, float], Tuple[float, float, float]]
+
+
+def add_strut(struts: Sequence[Strut], a: Sequence[float], b: Sequence[float]) -> List[Strut]:
+    """Return a new list with a strut appended."""
+    new = list(struts)
+    new.append((tuple(a), tuple(b)))
+    return new
+
+
+def edit_strut(struts: Sequence[Strut], index: int, a: Sequence[float], b: Sequence[float]) -> List[Strut]:
+    """Return a new list with the strut at *index* replaced."""
+    new = list(struts)
+    new[index] = (tuple(a), tuple(b))
+    return new
+
+
+def delete_strut(struts: Sequence[Strut], index: int) -> List[Strut]:
+    """Return a new list with the strut at *index* removed."""
+    new = list(struts)
+    del new[index]
+    return new
+
+
+__all__ = ["Strut", "add_strut", "edit_strut", "delete_strut"]

--- a/tests/test_editor_state.py
+++ b/tests/test_editor_state.py
@@ -1,0 +1,18 @@
+from tensegritylab.editor_state import add_strut, edit_strut, delete_strut
+
+
+def test_round_trip_add_edit_delete():
+    struts = []
+    # add
+    s1 = add_strut(struts, (0, 0, 0), (1, 0, 0))
+    assert struts == []  # original not mutated
+    assert s1 == [((0.0, 0.0, 0.0), (1.0, 0.0, 0.0))]
+
+    # edit
+    s2 = edit_strut(s1, 0, (0, 0, 0), (1, 1, 1))
+    assert s1 == [((0.0, 0.0, 0.0), (1.0, 0.0, 0.0))]
+    assert s2 == [((0.0, 0.0, 0.0), (1.0, 1.0, 1.0))]
+
+    # delete
+    s3 = delete_strut(s2, 0)
+    assert s3 == []


### PR DESCRIPTION
## Summary
- Add custom strut editor with Plotly 3D and auto-planning in Streamlit app
- Provide utilities to add/edit/delete struts and expose them as testable helpers
- Verify strut state operations with round-trip unit test

## Testing
- `pytest tests/test_editor_state.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install -q numpy pandas` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e8d31c38832c9d0fcd938f3dec02